### PR TITLE
Fix panic object nil

### DIFF
--- a/promlinter.go
+++ b/promlinter.go
@@ -211,6 +211,9 @@ func parseValue(n ast.Node) (string, bool) {
 	case *ast.BasicLit:
 		return mustUnquote(t.Value), true
 	case *ast.Ident:
+		if t.Obj == nil {
+			return "", false
+		}
 		if vs, ok := t.Obj.Decl.(*ast.ValueSpec); !ok {
 			return "", false
 		} else {


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

When the ast.Ident object is nil, usually this is the case that object is in other packages, this time causes a panic.