### PR TITLE
quickfix: panic

### DIFF
--- a/promlinter.go
+++ b/promlinter.go
@@ -250,6 +250,10 @@ func (v *visitor) parseCallerExpr(call *ast.CallExpr) ast.Visitor {
 		return v
 	}
 
+	if len(call.Args) == 0 {
+		return v
+	}
+
 	return v.parseOpts(call.Args[0], metricType)
 }
 


### PR DESCRIPTION
This commits fixes the panic on matching any function with a suitable name (`Counter`, `Gauge`, etc...) with no arguments. It doesn't resolve the problem of correct determination of Prometheus's metric functions or interfaces. 

Fixes https://github.com/yeya24/promlinter/issues/30

