### PR TITLE
add support for json/yaml output to list

### DIFF
--- a/cmd/promlinter/main.go
+++ b/cmd/promlinter/main.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/yeya24/promlinter"
 )
@@ -60,7 +61,7 @@ func main() {
 		Default("false").Short('s').Bool()
 	listPrintAddPos := listCmd.Flag("add-position", "Add metric position column when printing the result.").Default("false").Bool()
 	listPrintAddHelp := listCmd.Flag("add-help", "Add metric help column when printing the result.").Default("false").Bool()
-	listPrintJSON := listCmd.Flag("json", "Print result as json.").Default("false").Bool()
+	listPrintFormat := listCmd.Flag("output", "Print result formatted as JSON/YAML").Short('o').Enum("yaml", "json")
 
 	lintCmd := app.Command("lint", "Lint metrics via promlint.")
 	lintPaths := lintCmd.Arg("files", "Files to parse metrics.").Strings()
@@ -77,7 +78,7 @@ func main() {
 	switch parsedCmd {
 	case listCmd.FullCommand():
 		metrics := promlinter.RunList(fileSet, findFiles(*listPaths, fileSet), *listStrict)
-		printMetrics(metrics, *listPrintAddPos, *listPrintAddHelp, *listPrintJSON)
+		printMetrics(metrics, *listPrintAddPos, *listPrintAddHelp, *listPrintFormat)
 	case lintCmd.FullCommand():
 		setting := promlinter.Setting{Strict: *lintStrict, DisabledLintFuncs: *disableLintFuncs}
 		for _, iss := range promlinter.RunLint(fileSet, findFiles(*lintPaths, fileSet), setting) {
@@ -130,10 +131,16 @@ func walkDir(root string) chan string {
 	return out
 }
 
-func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp, asJson bool) {
-	if asJson {
-		printAsJson(metrics)
-		return
+func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp bool, printFormat string) {
+	if len(printFormat) > 0 {
+		if printFormat == "json" {
+			printAsJson(metrics)
+			return
+		}
+		if printFormat == "yaml" {
+			printAsYaml(metrics)
+			return
+		}
 	}
 	tw := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 	defer tw.Flush()
@@ -164,8 +171,17 @@ func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp
 	}
 }
 
-func printAsJson(metrics []promlinter.MetricFamilyWithPos) {
+func printAsYaml(metrics []promlinter.MetricFamilyWithPos) {
+	b, err := yaml.Marshal(toPrint(metrics))
+	if err != nil {
+		fmt.Printf("Failed: %v", err)
+		os.Exit(1)
+	}
+	fmt.Print(string(b))
 
+}
+
+func printAsJson(metrics []promlinter.MetricFamilyWithPos) {
 	b, err := json.Marshal(toPrint(metrics))
 	if err != nil {
 		fmt.Printf("Failed: %v", err)

--- a/cmd/promlinter/main.go
+++ b/cmd/promlinter/main.go
@@ -186,15 +186,29 @@ type MetricForPrinting struct {
 func toPrint(metrics []promlinter.MetricFamilyWithPos) []MetricForPrinting {
 	p := []MetricForPrinting{}
 	for _, m := range metrics {
-		i := MetricForPrinting{
-			Name:     *m.MetricFamily.Name,
-			Help:     *m.MetricFamily.Help,
-			Type:     MetricType[int32(*m.MetricFamily.Type)],
-			Filename: m.Pos.Filename,
-			Line:     m.Pos.Line,
-			Column:   m.Pos.Column,
+		if m.MetricFamily != nil && *m.MetricFamily.Name != "" {
+			if m.MetricFamily.Type == nil {
+				continue
+			}
+			n := ""
+			h := ""
+
+			if m.MetricFamily.Name != nil {
+				n = *m.MetricFamily.Name
+			}
+			if m.MetricFamily.Help != nil {
+				h = *m.MetricFamily.Help
+			}
+			i := MetricForPrinting{
+				Name:     n,
+				Help:     h,
+				Type:     MetricType[int32(*m.MetricFamily.Type)],
+				Filename: m.Pos.Filename,
+				Line:     m.Pos.Line,
+				Column:   m.Pos.Column,
+			}
+			p = append(p, i)
 		}
-		p = append(p, i)
 	}
 	return p
 }

--- a/cmd/promlinter/main.go
+++ b/cmd/promlinter/main.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/yeya24/promlinter"
 )
@@ -58,6 +60,7 @@ func main() {
 		Default("false").Short('s').Bool()
 	listPrintAddPos := listCmd.Flag("add-position", "Add metric position column when printing the result.").Default("false").Bool()
 	listPrintAddHelp := listCmd.Flag("add-help", "Add metric help column when printing the result.").Default("false").Bool()
+	listPrintJSON := listCmd.Flag("json", "Print result as json.").Default("false").Bool()
 
 	lintCmd := app.Command("lint", "Lint metrics via promlint.")
 	lintPaths := lintCmd.Arg("files", "Files to parse metrics.").Strings()
@@ -74,7 +77,7 @@ func main() {
 	switch parsedCmd {
 	case listCmd.FullCommand():
 		metrics := promlinter.RunList(fileSet, findFiles(*listPaths, fileSet), *listStrict)
-		printMetrics(metrics, *listPrintAddPos, *listPrintAddHelp)
+		printMetrics(metrics, *listPrintAddPos, *listPrintAddHelp, *listPrintJSON)
 	case lintCmd.FullCommand():
 		setting := promlinter.Setting{Strict: *lintStrict, DisabledLintFuncs: *disableLintFuncs}
 		for _, iss := range promlinter.RunLint(fileSet, findFiles(*lintPaths, fileSet), setting) {
@@ -127,7 +130,11 @@ func walkDir(root string) chan string {
 	return out
 }
 
-func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp bool) {
+func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp, asJson bool) {
+	if asJson {
+		printAsJson(metrics)
+		return
+	}
 	tw := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 	defer tw.Flush()
 
@@ -155,4 +162,39 @@ func printMetrics(metrics []promlinter.MetricFamilyWithPos, addPosition, addHelp
 			fmt.Fprintf(tw, "%v\t%v\n", MetricType[int32(*m.MetricFamily.Type)], *m.MetricFamily.Name)
 		}
 	}
+}
+
+func printAsJson(metrics []promlinter.MetricFamilyWithPos) {
+
+	b, err := json.Marshal(toPrint(metrics))
+	if err != nil {
+		fmt.Printf("Failed: %v", err)
+		os.Exit(1)
+	}
+	fmt.Print(string(b))
+}
+
+type MetricForPrinting struct {
+	Name     string
+	Help     string
+	Type     string
+	Filename string
+	Line     int
+	Column   int
+}
+
+func toPrint(metrics []promlinter.MetricFamilyWithPos) []MetricForPrinting {
+	p := []MetricForPrinting{}
+	for _, m := range metrics {
+		i := MetricForPrinting{
+			Name:     *m.MetricFamily.Name,
+			Help:     *m.MetricFamily.Help,
+			Type:     MetricType[int32(*m.MetricFamily.Type)],
+			Filename: m.Pos.Filename,
+			Line:     m.Pos.Line,
+			Column:   m.Pos.Column,
+		}
+		p = append(p, i)
+	}
+	return p
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -449,6 +451,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This PR adds support to print the output of list in json format. 
The format is quite handy it you want to process further e.g. during generation of documentation.

use `-oyaml` / `--ojson` `--output= ...`